### PR TITLE
Feature/up 2007 request id refactoring

### DIFF
--- a/src/main/scala/com/ubirch/niomon/base/NioMicroservice.scala
+++ b/src/main/scala/com/ubirch/niomon/base/NioMicroservice.scala
@@ -118,7 +118,9 @@ trait NioMicroservice[I, O] {
 
     logger.error(s"error sink has received an exception, sending on [$errorTopic]", exception)
 
-    val stringifiedException = stringifyException(exception, record.key())
+    val requestId = record.requestIdHeader().orNull
+
+    val stringifiedException = stringifyException(exception, requestId)
 
     val errRecord: ProducerRecord[String, String] = record.copy(topic = errorTopic, value = stringifiedException)
     val errRecordWithStatus = status match {

--- a/src/main/scala/com/ubirch/niomon/base/NioMicroserviceLive.scala
+++ b/src/main/scala/com/ubirch/niomon/base/NioMicroserviceLive.scala
@@ -185,7 +185,7 @@ final class NioMicroserviceLive[Input, Output](
   lazy val logic: NioMicroserviceLogic[Input, Output] = logicFactory(this)
 
   /** @see [[NioMicroserviceLogic.processRecord]] */
-  def processRecord(input: ConsumerRecord[String, Input]): ProducerRecord[String, Output] = logic.processRecord(input)
+  def processRecord(record: ConsumerRecord[String, Input]): ProducerRecord[String, Output] = logic.processRecord(record)
 
   /** The akka-streaming graph for running the microservice. */
   def graph: RunnableGraph[DrainingControl[Done]] = {

--- a/src/main/scala/com/ubirch/niomon/base/NioMicroserviceLogic.scala
+++ b/src/main/scala/com/ubirch/niomon/base/NioMicroserviceLogic.scala
@@ -20,18 +20,18 @@ abstract class NioMicroserviceLogic[I, O](runtime: NioMicroservice[I, O]) extend
   final def stringifyException(e: Throwable, reqId: String): String = runtime.stringifyException(e, reqId)
 
   /** The business logic of the microservice */
-  def processRecord(input: ConsumerRecord[String, I]): ProducerRecord[String, O]
+  def processRecord(record: ConsumerRecord[String, I]): ProducerRecord[String, O]
 }
 
 object NioMicroserviceLogic {
   abstract class Simple[I, O](runtime: NioMicroservice[I, O]) extends NioMicroserviceLogic[I, O](runtime) {
-    final def processRecord(input: ConsumerRecord[String, I]): ProducerRecord[String, O] = {
-      val (output, topicKey) = process(input.value())
-      input.toProducerRecord(topic = outputTopics(topicKey), value = output)
+    final def processRecord(record: ConsumerRecord[String, I]): ProducerRecord[String, O] = {
+      val (output, topicKey) = process(record.value())
+      record.toProducerRecord(topic = outputTopics(topicKey), value = output)
     }
 
     /** Simpler version of [[NioMicroserviceLogic.processRecord]]. You only get the value of the input record and you
      * return a tuple (output value, destination topic alias (see [[NioMicroservice.outputTopics]])) */
-    def process(input: I): (O, String)
+    def process(record: I): (O, String)
   }
 }

--- a/src/test/scala/com/ubirch/niomon/base/NioMicroserviceTest.scala
+++ b/src/test/scala/com/ubirch/niomon/base/NioMicroserviceTest.scala
@@ -16,7 +16,7 @@ class NioMicroserviceTest extends FlatSpec with Matchers with EmbeddedKafka with
     withRunningKafka {
       var n = 0
       val microservice = NioMicroserviceLive[String, String]("test", new NioMicroserviceLogic.Simple(_) {
-        override def process(input: String): (String, String) = {
+        override def process(record: String): (String, String) = {
           n += 1
           s"foobar$n" -> "default"
         }
@@ -46,7 +46,7 @@ class NioMicroserviceTest extends FlatSpec with Matchers with EmbeddedKafka with
       val microservice = NioMicroserviceLive[String, String]("test-with-error", new NioMicroserviceLogic.Simple(_) {
         var first = true
 
-        override def process(input: String): (String, String) = {
+        override def process(record: String): (String, String) = {
           if (first) {
             first = false
             throw new RuntimeException("foobar")
@@ -76,7 +76,7 @@ class NioMicroserviceTest extends FlatSpec with Matchers with EmbeddedKafka with
   it should "shutdown on error with no error topic configured" in {
     withRunningKafka {
       val microservice = NioMicroserviceLive[String, String]("test1", new NioMicroserviceLogic.Simple(_) {
-        override def process(input: String): (String, String) = {
+        override def process(record: String): (String, String) = {
           throw new RuntimeException("foobar")
         }
       })
@@ -94,7 +94,7 @@ class NioMicroserviceTest extends FlatSpec with Matchers with EmbeddedKafka with
   it should "continue processing after kafka goes down for a while" taggedAs(Slow) ignore {
     withRunningKafka {
       val microservice = NioMicroserviceLive[String, String]("faulty-kafka", new NioMicroserviceLogic.Simple(_) {
-        override def process(input: String): (String, String) = s"success-$input" -> "default"
+        override def process(record: String): (String, String) = s"success-$record" -> "default"
       })
       val control = microservice.run
 
@@ -129,9 +129,9 @@ class NioMicroserviceTest extends FlatSpec with Matchers with EmbeddedKafka with
 
   it should "handle long running NioMicroserviceLogics" taggedAs(Slow) ignore {
     val microservice = NioMicroserviceLive[String, String]("test-long", new NioMicroserviceLogic.Simple(_) {
-      override def process(input: String): (String, String) = {
+      override def process(record: String): (String, String) = {
         Thread.sleep(20000)
-        s"success-$input" -> "default"
+        s"success-$record" -> "default"
       }
     })
     val control = microservice.run


### PR DESCRIPTION
Using the request id as part of the key field for a producer record values makes the partitioning of the data to be unbalanced. This PR moves the request id from the key to a header in the record.