### PR TITLE
Payload as bytes - Parent POM fix - Scala Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.ubirch.niomon</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
+        <relativePath>../parent</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>foundation</artifactId>
     <version>1.0.1-SNAPSHOT</version>


### PR DESCRIPTION
UP-1885 Support for payload as bytes for success with requestId
UP-2301 Fix to parent reference.
UP-2302 Fix Scala incompatibility with internal lib. Scala upgrade.